### PR TITLE
fix deoplete#sources#jedi#show_docstring

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_jedi.py
+++ b/rplugin/python3/deoplete/sources/deoplete_jedi.py
@@ -84,7 +84,7 @@ class Source(Base):
                 'deoplete#sources#jedi#short_types']
         self.show_docstring = False
         if 'deoplete#sources#jedi#show_docstring' in vars:
-            self.use_short_types = vars[
+            self.show_docstring = vars[
                 'deoplete#sources#jedi#show_docstring']
         self.ignore_errors = False
         if 'deoplete#sources#jedi#ignore_errors' in vars:


### PR DESCRIPTION
`let g:deoplete#sources#jedi#show_docstring = 1` has no effect due to a simple bug (typo).
This PR fixes it.